### PR TITLE
fix: rm -rf命令在windows上无法运行，使用rimraf包兼容处理mac和windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "chaosblade-box-frondend",
   "version": "1.0.0",
   "scripts": {
-    "clean": "rm -rf build",
+    "clean": "rimraf build",
     "dev": "npm run clean && cross-env NODE_ENV=development webpack-dev-server",
     "build": "npm run clean && cross-env NODE_ENV=production webpack",
     "lint": "eslint src --ext .js,.jsx,.ts,.tsx",
@@ -67,6 +67,7 @@
     "react-markdown": "^7.1.1",
     "reflect-metadata": "^0.1.13",
     "remark-gfm": "^3.0.1",
+    "rimraf": "^3.0.2",
     "sass-loader": "^12.1.0",
     "style-loader": "^2.0.0",
     "styled-components": "^4.2.0",


### PR DESCRIPTION
rm -rf命令在windows电脑上运行报错，可以使用rimraf包兼容mac和windows系统